### PR TITLE
Add jsDelivr CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ or maybe you wish to use NPM...
 ```bash
 npm install node-snackbar
 ```
+
+you can also use a CDN and just include this in your code...
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/node-snackbar@0.1/dist/snackbar.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/node-snackbar@0.1/dist/snackbar.min.css">
+```
+
 and if that doesn't float you, you can always download the CSS and JS files...
 ```html
 <script type="text/javascript" src="dist/snackbar.min.js"></script>


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/) to the readme as it is the same as downloading it but easier and faster.