### PR TITLE
[Megan Gross - 09/30/2019] - Set attribute on the SnackBar div so scr…

### DIFF
--- a/demo/Snackbar.html
+++ b/demo/Snackbar.html
@@ -238,6 +238,20 @@
                     <td>Text to display as the action button.</td>
                   </tr>
                   <tr>
+                    <td>actionTextAria</td>
+                    <td>
+                      <i>Dismiss, Description for Screen Readers</i>
+                    </td>
+                    <td>Text for screen readers.</td>
+                  </tr>
+                  <tr>
+                    <td>alertScreenReader</td>
+                    <td>
+                      <i>false</i>
+                    </td>
+                    <td>Determines if screen readers will annouce the snackbar message.</td>
+                  </tr>
+                  <tr>
                     <td>actionTextColor</td>
                     <td>
                       <i>#4CAF50</i>

--- a/src/js/snackbar.js
+++ b/src/js/snackbar.js
@@ -30,6 +30,7 @@
         showAction: true,
         actionText: 'Dismiss',
         actionTextAria: 'Dismiss, Description for Screen Readers',
+        alertScreenReader: false,
         actionTextColor: '#4CAF50',
         showSecondButton: false,
         secondButtonText: '',
@@ -112,6 +113,10 @@
                 }.bind(Snackbar.snackbar),
                 options.duration
             );
+        }
+
+        if (options.alertScreenReader) {
+           Snackbar.snackbar.setAttribute('role', 'alert');
         }
 
         Snackbar.snackbar.addEventListener(


### PR DESCRIPTION
The current SnackBar implementation lacks the role=alert attribute that makes screen readers announce the snackbar message as it appears in the DOM. Without this attribute the actionTextAria option never gets read and the message quietly appears and then disappears, leaving visually impaired  users unaware of its existence.  Adding this line of code will allow screen reader users to hear the messages rendered by this library. 